### PR TITLE
chore: add Dependabot config for weekly version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot version + security updates.
+#
+# The "npm" package-ecosystem covers npm, yarn, and pnpm lockfiles —
+# there is no separate ecosystem value for the latter two.
+#
+# Major-version bumps are deliberately left out of the group below so each
+# breaking change arrives as its own reviewable PR.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to turn on Dependabot **version** updates (not just the security alerts already enabled org-wide).

### Why it's shaped this way

- **Minor + patch bumps are grouped into one weekly PR.** Ungrouped, Dependabot opens a PR per outdated package — on the larger repos in this org that's dozens on day one. Grouping is the difference between a config people keep and one they mute.
- **Major bumps are deliberately left out of the group**, so each breaking change arrives as its own reviewable PR.
- **`open-pull-requests-limit: 5`** caps the backlog.
- **Weekly, Monday 09:00 America/New_York** rather than daily.

### Notes

- `package-ecosystem: npm` covers npm, yarn, **and** pnpm — there is no separate ecosystem value for the latter two. Verified against GitHub's supported-ecosystems reference (pnpm v7–v10).
- No `github-actions` entry: this repo has no `.github/workflows`, so it would be dead config.

Nothing here changes application code. Merging turns the updates on; closing it leaves things exactly as they are.
